### PR TITLE
CSS: add custom css to handle overflow in model output

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,26 @@ st.set_page_config(
     page_icon="src/acm_logo_tablet.png",
 )
 
+# Add custom CSS to handle overflow
+st.markdown("""
+<style>
+.stMarkdown {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    max-width: 100%;
+}
+pre {
+    white-space: pre-wrap !important;
+    word-break: break-word !important;
+    overflow-x: auto !important;
+}
+code {
+    white-space: pre-wrap !important;
+    word-break: break-word !important;
+}
+</style>
+""", unsafe_allow_html=True)
+
 # import the SearchAgent class from the Agents module
 from Agents.websearchagent import SearchAgent
 


### PR DESCRIPTION
Remove the horizontal scroll as it's hard to read the output.

**Before this PR**
<img width="729" alt="Screen Shot 2025-03-29 at 2 54 41 PM" src="https://github.com/user-attachments/assets/02fba654-897c-4c7f-a16a-5ddf1649618a" />

**After this PR**
<img width="722" alt="Screen Shot 2025-03-29 at 2 55 10 PM" src="https://github.com/user-attachments/assets/b6fce045-7305-4aee-99c2-69d8f3796590" />
